### PR TITLE
Add package.json for easier linting for Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 CREDENTIALS
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "FirefoxNoMore404s",
+  "description": "Reduce annoying 404 pages by automatically checking for an archived copy in the Wayback Machine",
+  "version": "1.4.0",
+  "author": "Internet Archive",
+  "bugs": {
+    "url": "https://github.com/internetarchive/FirefoxNoMore404s/issues"
+  },
+  "devDependencies": {
+    "addons-linter": "0.11.0",
+    "eslint": "2.11.1"
+  },
+  "homepage": "https://github.com/internetarchive/FirefoxNoMore404s#readme",
+  "keywords": [],
+  "license": "AGPL-3",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/internetarchive/FirefoxNoMore404s.git"
+  },
+  "scripts": {
+    "build": "make build",
+    "lint": "eslint .",
+    "prebuild": "npm run lint",
+    "pretest": "npm run build",
+    "test": "addons-linter build/FirefoxNoMore404s.xpi -o text"
+  }
+}

--- a/src/scripts/client.js
+++ b/src/scripts/client.js
@@ -18,8 +18,8 @@
       matches[5],
       matches[6]
     ));
-    var options = { year: 'numeric', month: 'long', day: 'numeric' };
-    return utcDate.toLocaleString('en-us', options);
+    var options = { year: "numeric", month: "long", day: "numeric" };
+    return utcDate.toLocaleString("en-us", options);
   }
 
   /**


### PR DESCRIPTION
Fixes a couple ESLint errors, and makes it easier to get set up running ESLint (assuming you're a Node user).
Also makes it super easy to run the linting tasks automatically [in the future] if we enable Travis-CI for this repo.
Travis-CI will run `npm test` automatically (once enabled) which will trigger `make build` and `eslint .`, so we'll eventually be running ESLint against all the source, building the XPI (on Travis-CI) and then running the addons-linter against the generated XPI.