### PR TITLE
Fix ESLint error by adding BroadcastChannel global

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@ env:
 
 globals:
   chrome: false
+  BroadcastChannel: false
 
 root: true
 


### PR DESCRIPTION
Fixes ESLint error currently in master:

```sh
$ npm run lint

> FirefoxNoMore404s@1.5.3 lint /Users/pdehaan/dev/github/FirefoxNoMore404s
> eslint .


/Users/pdehaan/dev/github/FirefoxNoMore404s/src/scripts/background.js
  70:34  error  'BroadcastChannel' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```
