### PR TITLE
point updateurl to the main site

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
     "gecko": {
       "id": "wayback_machine@mozilla.org",
       "strict_min_version": "48.0",
-      "update_url": "https://testpilot.cdn.mozilla.net/nomore404s/nomore404s.json"
+      "update_url": "https://testpilot.firefox.com/files/nomore404s/nomore404s.json"
     }
   },
   "permissions": [


### PR DESCRIPTION
This is just cleaning up.  The redirect wasn't live when we launched, but it's where all the other add-ons point so this one should go there as well.  This isn't necessary to make a new build, it'll just go out next time we make one.