### PR TITLE
Don't require that users "speak HTTP"

### DIFF
--- a/src/scripts/client.js
+++ b/src/scripts/client.js
@@ -108,7 +108,7 @@
                 el.style.fontWeight = "700";
                 el.style.height = "54px";
                 el.style.justifyContent = "center";
-                el.appendChild(document.createTextNode("404? No Worries!"));
+                el.appendChild(document.createTextNode("Page missing? No worries!"));
               },
               createEl("button",
                 function(el) {


### PR DESCRIPTION
Remove the requirement for users to be familiar with HTTP status codes to make sense of the dialog. No room in UI for the full sentence "Is the page missing?" but this will suffice. Since commit 119ef4115a, the extension handles more situations than just 404 as well – so the message is not correct as-is anymore.